### PR TITLE
Added support for (manual) testing of PAC files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,59 +17,105 @@ This library returns the proper implementation of *fetch()* depending on the run
 - it returns the native [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) in a browser, as well as in a Electron `renderer` process
 - it returns [net.fetch](https://www.electronjs.org/docs/latest/api/net#netfetchinput-init) in the Electron `main` and `utility` processes
 
-## Tests
+## Tests components
 
-> **INFO**: execute `npm run docker:test` to run the tests in Docker/Linux
-
-We have automated tests in order to verify that this library behaves as expected in various situations:
+We need to test that this library behaves as expected in various situations, whatever the OS of the user:
 
 - in both the `main` process, a `renderer` process and a `utility` process
-- when connecting directly to a server
-- when connecting to a server that uses a self-signed certificate
-- when connecting to a server through a proxy that is configured in the operating system
+- when connecting directly to a server (aka when no proxy is involved)
+- when connecting to a server that uses a self-signed certificate whose authority has been installed in the trust store of the OS
+- when connecting to a server through a proxy that has been configured at the level of the OS
 - when connecting to a server through a proxy that requires basic authentication
+- when connecting to a server through the proxy returned by a [PAC file](https://en.wikipedia.org/wiki/Proxy_auto-config)
 
-Those tests involve multiple components:
+In order to perform those tests, we have prepared multiple components:
 
-- There is a `server` that exposes a REST API where clients can register themselves. It opens a port on the host to allow direct access.
-- There are `proxies` with various configurations. They each open a different port on the host to provide access to the `server` based on its name within the Docker network. That name is only reachable within the Docker network, aka through one of the proxies.
-- There is an Electron `app`. It queries the API of the `server` from both the `main` process, a `renderer` process and a `utility` process. Each process registers itself through the API of the `server`.
-- There are `tests` that queries the API of the `server` to verify that all clients could successfully register themselves, whatever the context of the connection.
-
-We use Docker `compose` to orchestrate those components.
+|Component|URL|Description|
+|-|-|-|
+|`server`|On your host (direct access): <br> http://localhost:8080 <br> https://localhost:4443 <br><br> In Docker network (access through proxy): http://server:8080 <br> https://server:4443|This server exposes the following REST endpoint: <br> `PUT /initiators/:connectionType/:initiator` <br> It allows clients to register themselves using arbitrary routes: <br> `/initiators/direct/main`, `initiators/proxy/renderer`, etc. <br><br> This server also exposes the following REST endpoint: <br> `GET /initiators/:connectionType/:initiator` <br> It can be used to check if a given client managed to reach the server to register itself.|
+|`app`|NA|This is an Electron application. It contacts the server from both the *main* process, a *renderer* process and a *utility* process. Each process registers itself as a distinct `:initiator`: `main`, `renderer` and `utility` respectively. The base URL of the endpoint - including the `:connectionType` - is passed to the application through an environment variable, making it possible to start different instances of the application to cover different cases (e.g. direct connection, connection through a proxy).|
+|`proxy`|http://localhost:3128|This is a proxy that does not require authentication.|
+|`proxy-basic-auth`|http://localhost:3129|This is a proxy that requires basic authentication. You can use `user1` as both username and password.|
+|PAC file|http://localhost:8081/proxy.pac|This is a PAC file that leads to using the proxy that does not require authentication.|
+|`tests`|NA|This is a set of tests that query the REST API of the server to verify that all clients could successfully register themselves, whatever the context of the connection.|
 
 ![diagram](./doc/test-components.drawio.svg)
 
-## Observations
+## Test pre-requisites
 
-### :white_check_mark: Direct connection
+Follow the instructions below prior to executing the tests:
 
-Connecting directly to a server works as expected from all Electron processes.
+- Install both `node/npm` and `docker`.
+- Run `npm install` in this repository.
 
-### :white_check_mark: Connection involving a self-signed certificate
+## Test execution
 
-> **CONTEXT:** for a certificate to be considered valid, it must be signed by a trusted certificate authority (CA), such as *GlobalSign* or *DigiCert*.
+If your OS is **Linux or MacOS**, then you can run the command below to execute the automated tests.
+
+```sh
+npm run docker:test
+```
+
+:warning: Those tests validate the behavior of the library in Docker/Linux. Validating the library for MacOS and Windows involve manual steps that are documented below.
+
+### Direct connection
+
+In this case, the app connects directly to the server. There is no intermediate proxy involved.
+
+:white_check_mark: **Linux**: this case is covered by the automated tests.
+
+:white_check_mark: **MacOS**: follow the instructions below.
+
+1. Start the server with `npm run docker:server`.
+1. Start the application with `npm run test:app:direct`.
+
+### Connection involving a self-signed certificate
+
+For a certificate to be considered valid, it must be signed by a trusted certificate authority (CA), such as *GlobalSign* or *DigiCert*.
 Obtaining such a certificate used to cost some money (this is not true anymore thanks to *[Let's Encrypt](https://letsencrypt.org/)*, a nonprofit certificate authority).
 That's why some organizations generated their own self-signed certificates, typically for internal use.
-Those certificates are free. However, they are invalid by default and prevent HTTPS connections from being securely established.
+Those certificates are free.
+However, they are unsafe and prevent HTTPS connections from being established.
 To be able to use self-signed certificates, an organization must add itself to the list of trusted certificate authorities in the OS of all its users.
 
-Connecting to a server that uses a self-signed certificate works as expected from all Electron processes.
-Of course it requires the [root CA file](./test/resources/certs/gen/rootCA.crt) to be properly installed in the user's operating system.
+:white_check_mark: **Linux**: this case is covered by the automated tests. Note that the custom certificate authority must be added to the *NSS Shared DB* (see instructions [here](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/cert_management.md)).
 
-- MacOS: double-click on the root CA file and follow the instructions to add it to the *Keychain*
-- Windows: double-click on the root CA file and follow the instructions
-- Linux: see instructions [here](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/cert_management.md) to add the root CA to the *NSS Shared DB*
+:white_check_mark: **MacOS**: follow the instructions below.
 
-### :white_check_mark: Connection through a proxy
+1. Start the server with `npm run docker:server`.
+1. Open the MacOS *Keychain Access*.
+1. Click on *File* > *Import Items*.
+1. Select the certificate [./test/resources/certs/gen/rootCA.crt](./test/resources/certs/gen/rootCA.crt).
+1. Locate the certificate that you just imported in your keychain (it is named *Hackolade-Test-Root-CA*) and double click on it.
+1. In the *Trust* section of the details dialog, choose to *Always Trust* the certificate for SSL.
+1. Close the details dialog to apply your changes.
+1. Start the application with `npm run test:app:cert`.
+1. [Optional] You can remove the certificate from your keychain.
 
-Connecting to the server through the proxy that is configured in the operating system works as expected from all Electron processes.
+### Connection through a proxy
 
-### :white_check_mark: Connection through a proxy with basic auth
+In this case, the app connects to the server through a proxy.
 
-Connecting to the server through the proxy that is configured in the operating system requires some attention when basic authentication is involved.
-Even though the credentials might have been set at the level of the operating system, the user needs to provide them interactively to Electron.
-This is the case for apps such as Slack or Docker Desktop.
+:white_check_mark: **Linux**: this case is covered by the automated tests. Note that the proxy is configured through the environment variables `HTTP_PROXY` and `HTTPS_PROXY`, which is the standard way of configuring proxies in Linux.
+
+:white_check_mark: **MacOS**: follow the instructions below.
+
+1. Start the server with `npm run docker:server`.
+1. Open the MacOS *System Settings*.
+1. Select *Network* in the left menu.
+1. Navigate to the details of your network connection.
+1. In the details dialog, select *Proxies*.
+1. Enable *Web proxy (HTTP)* and provide the following settings:
+    - Server: localhost
+    - Port: 3128
+    - No authentication required
+1. Click on *OK* to apply your changes.
+1. Start the application with `npm run test:app:proxy`.
+1. Turn off the proxy.
+
+### Connection through a proxy with basic auth
+
+In this case, the app connects to the server through a proxy that requires a username and a password. Even though the credentials might have been set at the level of the operating system, the user needs to provide them interactively to the Electron application. Note that this is also the case for other apps such as Slack or Docker Desktop.
 
 The `main` process must handle the [login](https://www.electronjs.org/docs/latest/api/app#event-login) event and prompt the user for the proxy credentials.
 
@@ -95,3 +141,21 @@ const { utilityProcess } = require('electron');
 
 utilityProcess.fork(..., { respondToAuthRequestsFromMainProcess: true });
 ```
+
+:white_check_mark: **Linux**: this case is covered by the automated tests. Note that the proxy is configured through the environment variables `HTTP_PROXY` and `HTTPS_PROXY`, which is the standard way of configuring proxies in Linux.
+
+:white_check_mark: **MacOS**: follow the instructions below.
+
+1. Start the server with `npm run docker:server`.
+1. Open the MacOS *System Settings*.
+1. Select *Network* in the left menu.
+1. Navigate to the details of your network connection.
+1. In the details dialog, select *Proxies*.
+1. Enable *Web proxy (HTTP)* and provide the following settings:
+    - Server: localhost
+    - Port: 3128
+    - Username: user1
+    - Password: user1
+1. Click on *OK* to apply your changes.
+1. Start the application with `npm run test:app:proxy-basic-auth`. Note that you won't be prompted for credentials because we hardcoded them.
+1. Turn off the proxy.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Follow the instructions below prior to executing the tests:
 - Install both `node/npm` and `docker`.
 - Run `npm install` in this repository.
 
-## Test execution
+## Test automation
 
 If your OS is **Linux or MacOS**, then you can run the command below to execute the automated tests.
 
@@ -58,7 +58,7 @@ npm run docker:test
 
 :warning: Those tests validate the behavior of the library in Docker/Linux. Validating the library for MacOS and Windows involve manual steps that are documented below.
 
-### Direct connection
+## Test direct connection
 
 In this case, the app connects directly to the server. There is no intermediate proxy involved.
 
@@ -69,7 +69,7 @@ In this case, the app connects directly to the server. There is no intermediate 
 1. Start the server with `npm run docker:server`.
 1. Start the application with `npm run test:app:direct`.
 
-### Connection involving a self-signed certificate
+## Test connection involving a self-signed certificate
 
 For a certificate to be considered valid, it must be signed by a trusted certificate authority (CA), such as *GlobalSign* or *DigiCert*.
 Obtaining such a certificate used to cost some money (this is not true anymore thanks to *[Let's Encrypt](https://letsencrypt.org/)*, a nonprofit certificate authority).
@@ -92,7 +92,7 @@ To be able to use self-signed certificates, an organization must add itself to t
 1. Start the application with `npm run test:app:cert`.
 1. [Optional] You can remove the certificate from your keychain.
 
-### Connection through a proxy
+## Test connection through a proxy
 
 In this case, the app connects to the server through a proxy.
 
@@ -113,7 +113,7 @@ In this case, the app connects to the server through a proxy.
 1. Start the application with `npm run test:app:proxy`.
 1. Turn off the proxy.
 
-### Connection through a proxy with basic auth
+## Test connection through a proxy with basic auth
 
 In this case, the app connects to the server through a proxy that requires a username and a password. Even though the credentials might have been set at the level of the operating system, the user needs to provide them interactively to the Electron application. Note that this is also the case for other apps such as Slack or Docker Desktop.
 

--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ In this case, the app connects to the server through a proxy.
 1. Navigate to the details of your network connection.
 1. In the details dialog, select *Proxies*.
 1. Enable *Web proxy (HTTP)* and provide the following settings:
-    - Server: localhost
-    - Port: 3128
+    - Server: *localhost*
+    - Port: *3128*
     - No authentication required
 1. Click on *OK* to apply your changes.
 1. Start the application with `npm run test:app:proxy`.
 1. Turn off the proxy.
 
-## Test connection through a proxy with basic auth
+## Test connection through a proxy that requires basic auth
 
 In this case, the app connects to the server through a proxy that requires a username and a password. Even though the credentials might have been set at the level of the operating system, the user needs to provide them interactively to the Electron application. Note that this is also the case for other apps such as Slack or Docker Desktop.
 
@@ -152,10 +152,26 @@ utilityProcess.fork(..., { respondToAuthRequestsFromMainProcess: true });
 1. Navigate to the details of your network connection.
 1. In the details dialog, select *Proxies*.
 1. Enable *Web proxy (HTTP)* and provide the following settings:
-    - Server: localhost
-    - Port: 3128
-    - Username: user1
-    - Password: user1
+    - Server: *localhost*
+    - Port: *3128*
+    - Username: *user1*
+    - Password: *user1*
 1. Click on *OK* to apply your changes.
 1. Start the application with `npm run test:app:proxy-basic-auth`. Note that you won't be prompted for credentials because we hardcoded them.
+1. Turn off the proxy.
+
+## Test connection through a proxy configured via a PAC file
+
+:warning: **Linux**: PAC files are not natively supported by Linux, aka you cannot set `HTTP_PROXY` or `HTTPS_PROXY` to the URL of a PAC file. Linux requires the application itself to provide support for PAC files. That's because PAC files were originally meant to be used by browsers (see [here](https://en.wikipedia.org/wiki/Proxy_auto-config)). That's why they are JavaScript files.
+
+:white_check_mark: **MacOS**: follow the instructions below.
+
+1. Start the server with `npm run docker:server`.
+1. Open the MacOS *System Settings*.
+1. Select *Network* in the left menu.
+1. Navigate to the details of your network connection.
+1. In the details dialog, select *Proxies*.
+1. Enable *Auto proxy configuration* and provide the following URL: *http://localhost:8081/proxy.pac*.
+1. Click on *OK* to apply your changes.
+1. Start the application with `npm run test:app:proxy-pac-file`. Note that you won't be prompted for credentials because we hardcoded them.
 1. Turn off the proxy.

--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,8 @@ configs:
     file: ./test/resources/proxy/squid.conf
   squid-basic-auth:
     file: ./test/resources/proxy/squid-basic-auth.conf
+  pac-file:
+    file: ./test/resources/proxy/proxy.pac
 
 services:
 
@@ -45,6 +47,26 @@ services:
       - source: squid-basic-auth
         target: /etc/squid/squid.conf
 
+  nginx:
+    image: nginx:stable
+    ports:
+      - 8081:80
+    configs:
+      - source: pac-file
+        target: /usr/share/nginx/html/proxy.pac
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'sh',
+          '-exec',
+          'curl -sSL --fail http://localhost/proxy.pac',
+        ]
+      interval: 2s
+      timeout: 2s
+      retries: 5
+      start_period: 1s
+
   server:
     profiles: [test]
     build:
@@ -53,15 +75,15 @@ services:
       target: hck-fetch-test-server
     init: true
     ports:
-      - 8080:80
-      - 4443:443
+      - 8080:8080
+      - 4443:4443
     healthcheck:
       test:
         [
           'CMD',
           'sh',
           '-exec',
-          'curl -sSL --fail localhost/status',
+          'curl -sSL --fail localhost:8080/status',
         ]
       interval: 2s
       timeout: 2s
@@ -71,6 +93,8 @@ services:
       proxy:
         condition: service_healthy
       proxy-basic-auth:
+        condition: service_healthy
+      nginx:
         condition: service_healthy
 
   app: &app
@@ -116,7 +140,7 @@ services:
     profiles: [test]
     environment:
       - PORT=3003
-      - SERVER_API_URL=http://server/initiators/proxy
+      - SERVER_API_URL=http://server:8080/initiators/proxy
       - HTTP_PROXY=http://localhost:3128
       - HTTPS_PROXY=http://localhost:3128
 
@@ -125,7 +149,7 @@ services:
     profiles: [test]
     environment:
       - PORT=3004
-      - SERVER_API_URL=http://server/initiators/proxy-basic-auth
+      - SERVER_API_URL=http://server:8080/initiators/proxy-basic-auth
       - HTTP_PROXY=http://user1:user1@localhost:3129
       - HTTPS_PROXY=http://user1:user1@localhost:3129
     

--- a/doc/test-components.drawio.svg
+++ b/doc/test-components.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="751px" height="471px" viewBox="-0.5 -0.5 751 471" content="&lt;mxfile&gt;&lt;diagram id=&quot;NGK93fDsRziGN37oF_dM&quot; name=&quot;Page-1&quot;&gt;7Vpbk+IoFP41vloJ5KKPtto7VdM7WmrtdD8yBg21MViIre6vXzDkjrbdYrR21hdzDvfv43A4QAv2V/s/GFqHf9IARy1gBfsWHLQAsH2vI/6k5qA00PMTzZKRQOlyxZT8g5XSUtotCfCmlJFTGnGyLivnNI7xnJd0iDG6K2db0Kjc6hotcU0xnaOorv1JAh4qre1184RvmCxD1XQHqPGtUJpZjWQTooDuCio4bME+o5QnX6t9H0cSvRSXpNzzidSsYwzH/JICUPXjHUVbNTjVMX5IR8voNg6wLGC14NMuJBxP12guU3eCYKEL+SoSki0+FySK+jSi7FgWehbq2r7U05gX9IvjT+g3nNG/cZoS0xirSqaqAyHic4HZk+onZhzvTw7WziAUkw/TFebsILKoAk5HjVbNO+greZeTCNM5Fhb4sx2lRGriLLO6c2zFh4L3BDed20JtWa6FF48CdRnpTh1ox9EADUwADTQ4e5Fo4emX+FjKj+lw8tdwkqpFhVnKPSk5lrAHT/2sHzXANbSc5EAYX4kE26qzYAMNC54JEjo1JHEgFlElUsZDuqQxioa5toikGDY7vCrUj8KbFNrATeXBvpg6OCgpgTRdlsGZJakGPhj4nmVl4Mv+np/+wu0gtsS8MO/qbDAcIU7ey1XpoFVFx5SIRjIWbVhmscbOhm7ZHKtSOUE9xtChkG0tM2wub8e23QrfSY05+9kYL5oQ8GOrHE9Gr2+Pb5RXLYz+CTYbscnubWzSfyybTAxCeZkbmelnrQtU12LHrHU5V1mXyslSzY4IooD1C23IXA5yK8X/jAkC64426H68CRQFRCCDP0YVbdZJdLMge8lEFeagY1k+/AzMPdeyHMsMzE5lqcsgLcCsQxkYQLn726CcoZrGNHZzKKdNPTrMAWGiakJjoRfOgRuKcYB7P+h1SH/JlWdC4so/78nxnvDXvKyQ3tKS4juvRgppLU15f1uzS3evdP8XM+Q+CkOfRzvjtMhoxq+eU3MM2daVFOm3YK5dNlcnZeiDQOoLuzHgGeK+QPdbMa1x7v2myO82ZJ7wYcxTDzg4D/g9V1AIG+IobfxcVDN8GfZnk9EPka03Hl8W3qwQiVugf+yyiGEYZom05SQi/FCbGA0egNcZu2qL4lp+ec3TbFFud9wAH87E2k4HXrxLkcIYMyIGjlnTdgfM71y+dHDhV4Ll9JjQ1MFFOtBzNj4bTmfTm58L3tdSPQfcz1JtXbxcIWEw6n+XVybWj+Hs52jy/dHOadV9lgEqKndXmtMh/d2VASLgBR7vZdTvvXwbTWePZhEGGahc1LoaY9Be1BrhwDHktoqXVU3t3r/mbaDG24CGNnlp24aOrtvt9j1XIcNH1fDU5V8TXgHqrux+n+M9WH0t0uDxHvRq0IecC0h7sgrwHNE5ikK6ERu1Z92MF6PmZfxPPv6oqFBElhLIuUBJ7nqfJIZEtNZTCSsSBNEpwsuWpntbIulVD7psr073cYnrGAp+1A12SmC3W7cdnSOHJgj0zxO4wexdhp3/s3fp0ufolj5D9Akxf3KXBDH5y0U4/Bc=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="752px" height="471px" viewBox="-0.5 -0.5 752 471" content="&lt;mxfile&gt;&lt;diagram id=&quot;NGK93fDsRziGN37oF_dM&quot; name=&quot;Page-1&quot;&gt;7Vpbk+IoFP41vloJJEYfvfVM1cyuVtu10/3IGDTUxmAhtrq/fsFArmjH3phYM+uDlXMIl/N9HA4H0oHjzfELQ9vgD+rjsAMs/9iBkw4A7sAR/1JxihW248JYs2bEV7pUsSD/YKW0lHZPfLzLvcgpDTnZ5pVLGkV4yXM6xBg95F9b0TDf6xatcUmxWKKwrP1BfB4ord0bpAVfMVkHqus+8OKCDdIvK0t2AfLpIaOC0w4cM0p5/LQ5jnEowdO4xPWeLpQmA2M44lUqQDWOdxTulXFqYPykrWV0H/lYVrA6cHQICMeLLVrK0oPgV+gCvgmFZIvHFQnDMQ0pO9eFPQsNbE/qacQz+tX5J/Q7zujfWJdENMKqkYUaQID4UmA2KlumjH3HjONjRqUs/YLpBnN2Eq+oUqevrFXzDnpKPqQkQj3Hggx/tqOUSE2cddJ2iq14UPBe4KZ/X6gty7Xw6lGgziPdLwPtOAagQR1AAwPOvVD0MPopHtbyYTF9/mv6rNWiwaSkTUrONezJaFwPB8L5ciTYVpkFGxhY6NVBQr+EJPbFIqpEynhA1zRC4TTVZpEUZrPTq0L9LLxJoQtcLU+O2dLJSUkxpHpZBleWpBL4YOL1LOsa+ByxNea5aSatusoGwyHi5D0fOkzQqqpzSkSvCYs2zLNYYmdH92yJVa2UoCFj6JR5bStf2FXvx7bdAt9xiyn7iY2VJgT82Cvnz7PXt1/cKb0LbDbik4P7+KTXqk/G818Flabc9FbvAsW12KnXu5z/5F3qTaY1ByKIAtZPtCNLaeReir+MCwKrRR90P94EigoikcEfo4p22zi7WZGjZKIIs9+3LA/eAvPQtSznqrfdsAUsLHUJpBmYTSiDGlAe/DYoJ6jqnMZuDmXd1aPD7BMmmiY0EnoRLXhNOQ5w24PehPSnQnkixKH89kiOj4S/pnWF9KZriue0GSnoVu4U/W3DLt2tO/xXZsh9FIZuRzvhNMtowq+Z008zpL3m3omUa+fd1dEMfZBIfWI3Bno1cZ+h+y1b1jj33p3IH7TlnvBh3NMMOLgOeIMrKIRtcaRHcy2rGc7n1XKaDSJRB4zP4xSJC8MslvachISfSrOhwVPvSjRV35e4lpdf6Az7kvudMcCH86uu04eVtyZSmGNGhOGY3dnZQAPblU+dVniFDFmfDdZ1WqEtv+bYL9PFy+Luh4HtemrPAe15qm1KkgskTGbjb/KexPpz+vJj9vzt0Q5n1SVWDVQULqwMR0LmC6saiIAVwtz32Xj4/ets8fJoHlEjA4XbWdfgDMbb2Vo4cGoKW9kbqqa27JWiDTREG9DWzk4Ppqbz6m632+YqVPe97aUbvyaiAjTd0/0+Z3qw+IlIg2d6sFeCPuBcQDqUTYCnkC5RGNCd2Kg9mWa8MJHn8b/4xUdBhUKylkAuBXBy1zuSgBHR21AVbIjvh5cIz3ua6YMSSa/6isvulek+L3H9mpIfdW2tCRwMyr5jCuSwDgK96wTuMHuXaef/7FVd+hzT0lcTfUJMv7OLk5j0a0U4/Rc=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs>
         <pattern patternUnits="userSpaceOnUse" width="11.5" height="11.5" x="0" y="0" patternTransform="rotate(45)" id="mx-pattern-hatch-1-60a917-0">
             <line x1="0" y1="0" x2="0" y2="11.5" stroke="#60a917" stroke-width="1.5"/>
@@ -76,9 +76,9 @@
         <ellipse cx="440" cy="70" rx="10" ry="10" fill="#d80073" stroke="#a50040" pointer-events="all"/>
         <ellipse cx="90" cy="260" rx="10" ry="10" fill="#d80073" stroke="#a50040" pointer-events="all"/>
         <ellipse cx="220" cy="260" rx="10" ry="10" fill="#d80073" stroke="#a50040" transform="rotate(90,220,260)" pointer-events="all"/>
-        <path d="M 527 350 L 527.06 80.06 Q 527.06 70.06 517.06 70.05 L 458.24 70.01" fill="none" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 452.24 70 L 460.24 66.01 L 458.24 70.01 L 460.23 74.01 Z" fill="#2d7600" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 467 380 L 230 380.06 Q 220 380.06 220 370.06 L 220 278.24" fill="none" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 527 350 L 527 80 Q 527 70 517 70 L 458.24 70" fill="none" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 452.24 70 L 460.24 66 L 458.24 70 L 460.24 74 Z" fill="#2d7600" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 467 380 L 230 380 Q 220 380 220 370 L 220 278.24" fill="none" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 220 272.24 L 224 280.24 L 220 278.24 L 216 280.24 Z" fill="#2d7600" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
         <path d="M 467 395 L 100 395 Q 90 395 90 385 L 90 278.24" fill="none" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 90 272.24 L 94 280.24 L 90 278.24 L 86 280.24 Z" fill="#2d7600" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
@@ -92,7 +92,7 @@
                         <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <b>
-                                    ELECTRON APP
+                                    APP
                                 </b>
                                 <br/>
                                 main, renderer, utility
@@ -101,12 +101,12 @@
                     </div>
                 </foreignObject>
                 <text x="527" y="384" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    ELECTRON APP...
+                    APP...
                 </text>
             </switch>
         </g>
-        <path d="M 659.96 350 L 660 80.06 Q 660 70.06 650 70.06 L 458.24 70" fill="none" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 452.24 70 L 460.24 66 L 458.24 70 L 460.23 74 Z" fill="#2d7600" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 659.96 350 L 660 80 Q 660 70 650 70 L 458.24 70" fill="none" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 452.24 70 L 460.24 66 L 458.24 70 L 460.24 74 Z" fill="#2d7600" stroke="#2d7600" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="602" y="350" width="120" height="60" fill="#60a917" stroke="#2d7600" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docker:server:verbose": "npm run docker:compose -- --attach-dependencies server",
     "docker:test": "npm run docker:compose -- --exit-code-from=tests --wait-timeout=120",
     "test": "node --test ./test/*.spec.js",
-    "test:app": "electron --no-sandbox ./test/resources/electron-app/main.js",
+    "test:app": "electron ./test/resources/electron-app/main.js",
     "test:app:direct": "PORT=3001 SERVER_API_URL=http://localhost:8080/initiators/direct npm run test:app",
     "test:app:cert": "PORT=3002 SERVER_API_URL=https://localhost:4443/initiators/cert npm run test:app",
     "test:app:proxy": "PORT=3003 SERVER_API_URL=http://server:8080/initiators/proxy npm run test:app",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,17 @@
   },
   "scripts": {
     "build": "swc -C module.type=es6 ./src -o ./dist/esm/index.mjs && swc -C module.type=commonjs ./src -o ./dist/cjs/index.cjs",
-    "docker:compose": "docker compose --profile=test up --build --force-recreate --always-recreate-deps --attach-dependencies --remove-orphans",
+    "docker:compose": "docker compose --profile=test up --build --force-recreate --always-recreate-deps --remove-orphans",
     "docker:server": "npm run docker:compose -- server",
+    "docker:server:verbose": "npm run docker:compose -- --attach-dependencies server",
     "docker:test": "npm run docker:compose -- --exit-code-from=tests --wait-timeout=120",
     "test": "node --test ./test/*.spec.js",
-    "test:app": "electron ./test/resources/electron-app/main.js",
+    "test:app": "electron --no-sandbox ./test/resources/electron-app/main.js",
     "test:app:direct": "PORT=3001 SERVER_API_URL=http://localhost:8080/initiators/direct npm run test:app",
-    "test:app:proxy": "PORT=3002 SERVER_API_URL=http://server/initiators/proxy npm run test:app",
+    "test:app:cert": "PORT=3002 SERVER_API_URL=https://localhost:4443/initiators/cert npm run test:app",
+    "test:app:proxy": "PORT=3003 SERVER_API_URL=http://server:8080/initiators/proxy npm run test:app",
+    "test:app:proxy-basic-auth": "PORT=3004 SERVER_API_URL=http://server:8080/initiators/proxy-basic-auth npm run test:app",
+    "test:app:proxy-pac-file": "PORT=3005 SERVER_API_URL=http://server:8080/initiators/proxy-pac-file npm run test:app",
     "test:server": "DEBUG=hck-fetch* node ./test/resources/server/server.js"
   },
   "devDependencies": {

--- a/test/resources/electron-app/main.js
+++ b/test/resources/electron-app/main.js
@@ -10,6 +10,9 @@ app.disableHardwareAcceleration();
 
 const log = debug('hck-fetch').extend('test-app');
 
+const PROXY_USERNAME = 'user1';
+const PROXY_PASSWORD = PROXY_USERNAME;
+
 const PORT = Number.parseInt(process.env.PORT);
 if (!PORT) {
   throw new Error(`Expected env.PORT to be a positive integer, got '${process.env.PORT}'!`)
@@ -49,7 +52,7 @@ app.whenReady().then(async () => {
 
 app.on('login', (event, webContents, details, authInfo, callback) => {
   event.preventDefault();
-  callback('user1', 'user1');
+  callback(PROXY_USERNAME, PROXY_PASSWORD);
 });
 
 function startServer() {

--- a/test/resources/proxy/proxy.pac
+++ b/test/resources/proxy/proxy.pac
@@ -1,0 +1,3 @@
+function FindProxyForURL() {
+  return 'PROXY localhost:3128';
+};

--- a/test/resources/server/server.js
+++ b/test/resources/server/server.js
@@ -4,8 +4,8 @@ const fs = require('fs');
 const https = require('https');
 const path = require('path');
 
-const HTTP_PORT = 80;
-const HTTPS_PORT = 443;
+const HTTP_PORT = 8080;
+const HTTPS_PORT = 4443;
 const log = debug('hck-fetch').extend('test-server');
 
 function startServer() {


### PR DESCRIPTION
# Extract from README file

:warning: **Linux**: PAC files are not natively supported by Linux, aka you cannot set `HTTP_PROXY` or `HTTPS_PROXY` to the URL of a PAC file. Linux requires the application itself to provide support for PAC files. That's because PAC files were originally meant to be used by browsers (see [here](https://en.wikipedia.org/wiki/Proxy_auto-config)). That's why they are JavaScript files.

:white_check_mark: **MacOS**: follow the instructions below.

1. Start the server with `npm run docker:server`.
1. Open the MacOS *System Settings*.
1. Select *Network* in the left menu.
1. Navigate to the details of your network connection.
1. In the details dialog, select *Proxies*.
1. Enable *Auto proxy configuration* and provide the following URL: *http://localhost:8081/proxy.pac*.
1. Click on *OK* to apply your changes.
1. Start the application with `npm run test:app:proxy-pac-file`. Note that you won't be prompted for credentials because we hardcoded them.
1. Turn off the proxy.