### PR TITLE
Use azure docker registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# syntax=docker/dockerfile:1.8
+# syntax=docker/dockerfile:1.10
 
-ARG NODEJS_MAJOR_VERSION=18
-FROM node:${NODEJS_MAJOR_VERSION} AS node-runtime
+ARG NODEJS_MAJOR_VERSION=20
+FROM hackolade.azurecr.io/node:${NODEJS_MAJOR_VERSION} AS node-runtime
 
 # Install pre-requisites for running Electron in Docker
 FROM node-runtime AS electron-runtime

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@ set -e
 
 service dbus start >> /dev/null &
 dbus-daemon --session --address=$DBUS_SESSION_BUS_ADDRESS --nofork --nopidfile --syslog-only &
-xvfb-run --auto-servernum --server-args="-screen 0 800x600x24" "$@"
+exec xvfb-run --auto-servernum --server-args="-screen 0 800x600x24" "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cross-env": "7.0.3",
         "debug": "4.3.7",
         "electron": "32.1.2",
-        "express": "4.21.0",
+        "express": "4.21.1",
         "husky": "9.1.6",
         "lint-staged": "15.2.10",
         "prettier": "3.3.3"
@@ -921,10 +921,11 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1305,17 +1306,18 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -2391,10 +2393,11 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2407,15 +2410,6 @@
       "dependencies": {
         "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cross-env": "7.0.3",
     "debug": "4.3.7",
     "electron": "32.1.2",
-    "express": "4.21.0",
+    "express": "4.21.1",
     "husky": "9.1.6",
     "lint-staged": "15.2.10",
     "prettier": "3.3.3"


### PR DESCRIPTION
## Context

- Infrastructure alignement do use our internal registry
- Small npm audit fix (express)
- Tweak in Docker context

I chose to keep the syntax definition in Dockerfile unlike our similar change that leverage the `BUILDKIT_SYNTAX` build argument to centralize the definition.  In that repository it makes it more complex to maintain for now.