### PR TITLE
Release 1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 IntegrIT S.A. dba Hackolade
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ This library returns the proper implementation of *fetch()* depending on the run
 - it returns the native [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) in a browser, as well as in a Electron `renderer` process
 - it returns [net.fetch](https://www.electronjs.org/docs/latest/api/net#netfetchinput-init) in the Electron `main` and `utility` processes
 
+## Release process
+
+1. Bump the semantic `version` in [package.json](./package.json). Push/merge that change into the branch that you plan to release (`develop` typically).
+1. Trigger [the release workflow](https://github.com/hackolade/fetch/actions/workflows/release.yml) from the GitHub *Actions* for that branch. It will publish the library to the NPM registry as [@hackolade/fetch](https://www.npmjs.com/package/@hackolade/fetch). It will also create a GitHub release.
+
 ## Tests components
 
 We need to test that this library behaves as expected in various situations, whatever the OS of the user:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackolade/fetch",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "A HTTP client that works in the browser and in Electron",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",
@@ -12,6 +12,8 @@
   },
   "types": "./src/index.d.ts",
   "files": ["./doc", "./dist", "./src"],
+  "keywords": ["http", "https", "client", "fetch", "electron", "proxy", "certificate", "cert"],
+  "license": "MIT",
   "scripts": {
     "prebuild": "rimraf ./dist",
     "build": "swc -C module.type=es6 ./src -o ./dist/esm/index.mjs && swc -C module.type=commonjs ./src -o ./dist/cjs/index.cjs",


### PR DESCRIPTION
# Content

- Bumped `version` in `package.json` to `1.0.0`
- Added `keywords` in `package.json` in order to ease searching on the NPM registry
- Added MIT `license` in `package.json`
- Added  MIT `LICENSE` file
- Renamed release job from `publish` to `release` (publishing to NPM is just one step of the release job)
- Documented release process in README file