### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.1] - 2025-03-06
+
+### Fixed
+
+- Added `.js` extension to relative imports and exports for compliance with ESM requirement
+- Added _package.json_ with `{ "type": "module" }` in ESM build
+- Preserved dynamic import of _electron_ in both CommonJS and ESM builds

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This library also provides extensions to modular SDK's that allow setting a cust
 
 1. Open a pull request to bump the semantic `version` in [package.json](./package.json).
 1. Set the title of your pull request to `Release v<major>.<minor>.<patch>`.
-1. Document the content of the release in the description of your pull request.
+1. Document the content of the release in both the [CHANGELOG](./CHANGELOG.md) and the description of your pull request.
 1. Merge the pull request into the branch that you plan to release (`develop` typically).
 1. Trigger [the release workflow](https://github.com/hackolade/fetch/actions/workflows/release.yml) from the GitHub *Actions* for that branch. It will publish the library to the NPM registry as [@hackolade/fetch](https://www.npmjs.com/package/@hackolade/fetch). It will also create a [GitHub release](https://github.com/hackolade/fetch/releases) with the same description as the pull request you created.
 
@@ -354,6 +354,16 @@ In this case, the app connects to the server through the proxy that is returned 
 
 1. Start the server with `npm run docker:server`.
 1. Start the application with `npm run test:app:custom-proxy-pac-file`. It should render all connections with a green background.
+
+## Q&A
+
+### Why do I need to append the .js extension when importing and exporting relative TypeScript modules?
+
+TypeScript does not require you to specify the file extensions in imports and exports.
+However, the TypeScript code of this library is ultimately transpiled to both CommonJS and ESM.
+ESM requires imports and exports to be fully specified, aka to include the file extensions (see [here](https://nodejs.org/api/esm.html#mandatory-file-extensions)).
+The problem is that TypeScript transpilers do not modify imported and exported paths (see [here](https://github.com/swc-project/swc/issues/5346)).
+So the only workaround is to use the `.js` extension in the TypeScript imports and exports in order to be compliant with the ESM requirement (see [here](https://www.typescriptlang.org/docs/handbook/modules/appendices/esm-cjs-interop.html#different-module-resolution-algorithms)).
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackolade/fetch",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A HTTP client that works in the browser and in Electron",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -30,9 +30,10 @@
   "repository": "github:hackolade/fetch",
   "scripts": {
     "prebuild": "rimraf ./dist",
-    "build:esm": "swc -C module.type=es6 ./src -d ./dist/esm --ignore **/*.d.ts --strip-leading-paths",
-    "build:cjs": "swc -C module.type=commonjs ./src -d ./dist/cjs --ignore **/*.d.ts --strip-leading-paths",
-    "build": "npm run build:esm && npm run build:cjs",
+    "build:esm:package": "echo '{ \"type\": \"module\" }' > ./dist/esm/package.json",
+    "build:esm": "swc ./src -d ./dist/esm --ignore **/*.d.ts --strip-leading-paths -C module.type=es6 -C module.ignoreDynamic=true",
+    "build:cjs": "swc ./src -d ./dist/cjs --ignore **/*.d.ts --strip-leading-paths -C module.type=commonjs -C module.ignoreDynamic=true",
+    "build": "npm run build:cjs && npm run build:esm && npm run build:esm:package",
     "docker:compose": "docker compose --profile=test up --build --force-recreate --always-recreate-deps --remove-orphans",
     "docker:server": "npm run docker:compose -- server",
     "docker:server:verbose": "npm run docker:compose -- --attach-dependencies server",

--- a/src/hckFetchAwsSdkHttpHandler.ts
+++ b/src/hckFetchAwsSdkHttpHandler.ts
@@ -3,7 +3,7 @@ import { HttpRequest, HttpResponse } from '@smithy/protocol-http';
 import { buildQueryString } from '@smithy/querystring-builder';
 import { HeaderBag, HttpHandlerOptions } from '@smithy/types';
 
-import { hckFetch } from './hckFetch';
+import { hckFetch } from './hckFetch.js';
 
 /**
  * The aws-sdk v3+ has a modular architecture that makes it possible to configure a request handler, aka the object

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from './hckFetch';
+export * from './hckFetch.js';
 
-export * from './hckFetchAwsSdkHttpHandler';
+export * from './hckFetchAwsSdkHttpHandler.js';


### PR DESCRIPTION
## [1.1.1] - 2025-03-06

### Fixed

- Added `.js` extension to relative imports and exports for compliance with ESM requirement
- Added _package.json_ with `{ "type": "module" }` in ESM build
- Preserved dynamic import of _electron_ in both CommonJS and ESM builds