### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-03-20
+
+### Fixed
+
+- Moved default export to barrel file for making this library a drop-in replacement of node-fetch
+
 ## [1.2.0] - 2025-03-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hackolade/fetch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hackolade/fetch",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@smithy/fetch-http-handler": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackolade/fetch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A HTTP client that works in the browser and in Electron",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/hckFetch.ts
+++ b/src/hckFetch.ts
@@ -44,9 +44,3 @@ async function fetchUsingGlobalContext(params: FetchParameters): FetchReturnType
 export function hckFetch(...params: FetchParameters): FetchReturnType {
   return useElectronNet() ? fetchUsingElectronNet(params) : fetchUsingGlobalContext(params);
 }
-
-/**
- * The default export aims at making this library a drop-in replacement for node-fetch.
- * @see https://github.com/googleapis/teeny-request/blob/4a5c834451a5649f68301385356677d8b3809054/src/index.ts#L30
- */
-export default hckFetch;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
+import { hckFetch } from './hckFetch.js';
+
 export * from './hckFetch.js';
 
 export * from './hckFetchAwsSdkHttpHandler.js';
+
+/**
+ * The default export aims at making this library a drop-in replacement for node-fetch.
+ * @see https://github.com/googleapis/teeny-request/blob/4a5c834451a5649f68301385356677d8b3809054/src/index.ts#L30
+ */
+export default hckFetch;


### PR DESCRIPTION
### Fixed

- Moved default export to barrel file for making this library a drop-in replacement of node-fetch