### PR TITLE
Release v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hackolade/fetch",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A HTTP client that works in the browser and in Electron",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -34,7 +34,7 @@
     "esbuild": "npx esbuild ./src/index.ts --bundle --tree-shaking=true --minify --external:electron",
     "build:esm": "npm run esbuild -- --outdir=./dist/esm --format=esm --platform=node --define:BROWSER_BUILD=false",
     "build:cjs": "npm run esbuild -- --outdir=./dist/cjs --format=cjs --platform=node --define:BROWSER_BUILD=false",
-    "build:browser": "npm run esbuild -- --outdir=./dist/browser --format=esm --platform=browser --define:BROWSER_BUILD=true",
+    "build:browser": "npm run esbuild -- --outdir=./dist/browser --format=iife --platform=browser --define:BROWSER_BUILD=true",
     "build": "npm run build:cjs && npm run build:esm && npm run build:esm:package && npm run build:browser",
     "docker:compose": "docker compose --profile=test up --build --force-recreate --always-recreate-deps --remove-orphans",
     "docker:server": "npm run docker:compose -- server",


### PR DESCRIPTION
# Content

- Change esbuild bundle format from esm to iife because esm can't be interpreted as is by the browser.